### PR TITLE
Pin requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy
-pandas
-numba
-blosc
-zstd
-tqdm
-dill
+numpy==1.14.2
+pandas==0.22.0
+numba==0.37.0
+blosc==1.5.1
+zstd==1.3.4
+tqdm==4.20.0
+dill==0.2.7.1


### PR DESCRIPTION
If you pin versions, it will make things in the long run easier for reproducibility.  Also, we make sure that we are testing the same versions that we are deploying.