### PR TITLE
Avoid repeating requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(name='strax',
       url='https://github.com/jelleaalbers/strax',
       setup_requires=['pytest-runner'],
       install_requires=req_file('requirements.txt'),
-      tests_require=requires + ['pytest', 'boltons', 'hypothesis'],
+      tests_require=req_file('requirements.txt') + req_file('requirements_tests.txt'),
       packages=['strax'])

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(name='strax',
       url='https://github.com/jelleaalbers/strax',
       setup_requires=['pytest-runner'],
       install_requires=req_file('requirements.txt'),
-      tests_require=req_file('requirements.txt') + req_file('requirements_tests.txt'),
+      tests_require=req_file('requirements.txt') + ['pytest', 'boltons', 'hypothesis'],
       packages=['strax'])

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
-requires = 'numpy pandas numba blosc zstd tqdm dill'.split()
-
+def req_file(filename):
+    with open(filename) as f:
+        content = f.readlines()
+    # you may also want to remove whitespace characters like `\n` at the end of each line
+    return [x.strip() for x in content] 
+    
 setup(name='strax',
       version='0.0.1',
       description='Streaming analysis for XENON',
@@ -12,6 +16,6 @@ setup(name='strax',
       author_email='j.aalbers@uva.nl',
       url='https://github.com/jelleaalbers/strax',
       setup_requires=['pytest-runner'],
-      install_requires=requires,
+      install_requires=req_file('requirements.txt'),
       tests_require=requires + ['pytest', 'boltons', 'hypothesis'],
       packages=['strax'])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def req_file(filename):
     with open(filename) as f:
         content = f.readlines()
     # you may also want to remove whitespace characters like `\n` at the end of each line
-    return [x.strip() for x in content] 
+    return [x.strip().split('=')[0] for x in content] 
     
 setup(name='strax',
       version='0.0.1',


### PR DESCRIPTION
Instead of repeating the requirements, you can just read requirements.txt then strip pinned versions.  See #6 